### PR TITLE
Add number(x) function

### DIFF
--- a/doc/custom/features.txt
+++ b/doc/custom/features.txt
@@ -59,7 +59,7 @@ By default the parser supports the following mathematical constants:
   <li>Unlimited number of arguments:<br/>
   <b>min, max, sum, avg</b><br/>&nbsp;</li>
   <li>String functions:<br/>
-  <b>str2dbl, length, toupper</b><br/>&nbsp;</li>
+  <b>str2dbl, number, length, toupper</b><br/>&nbsp;</li>
   <li>Complex functions:<br/>
   <b>real, imag, conj, arg, norm</b><br/>&nbsp;</li>  
   <li>Array functions:<br/>

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -235,7 +235,7 @@ MUP_NAMESPACE_START
 
   //------------------------------------------------------------------------------
   //
-  // String to double conversion
+  // String to double conversion => str2number()
   //
   //------------------------------------------------------------------------------
 
@@ -274,5 +274,47 @@ MUP_NAMESPACE_START
   IToken* FunStrToNumber::Clone() const
   {
     return new FunStrToNumber(*this);
+  }
+
+  //------------------------------------------------------------------------------
+  //
+  // String to double conversion => number()
+  //
+  //------------------------------------------------------------------------------
+
+  FunStrNumber::FunStrNumber()
+    :ICallback(cmFUNC, _T("number"), 1)
+  {}
+
+  //------------------------------------------------------------------------------
+  void FunStrNumber::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
+  {
+    assert(a_iArgc==1);
+    _unused(a_iArgc);
+
+    string_type in;
+    double out;
+
+    in = a_pArg[0]->GetString();
+
+#ifndef _UNICODE
+    sscanf(in.c_str(), "%lf", &out);
+#else
+    swscanf(in.c_str(), _T("%lf"), &out);
+#endif
+
+    *ret = (float_type)out;
+  }
+
+  //------------------------------------------------------------------------------
+  const char_type* FunStrNumber::GetDesc() const
+  {
+    return _T("number(s) - Converts the string stored in s into a floating foint value.");
+  }
+
+  //------------------------------------------------------------------------------
+  IToken* FunStrNumber::Clone() const
+  {
+    return new FunStrNumber(*this);
   }
 MUP_NAMESPACE_END

--- a/parser/mpFuncStr.h
+++ b/parser/mpFuncStr.h
@@ -127,6 +127,19 @@ MUP_NAMESPACE_START
     virtual const char_type* GetDesc() const override;
     virtual IToken* Clone() const override;
   }; // class FunStrToNumber
+
+  //------------------------------------------------------------------------------
+  /** \brief Parse string to a floating point value.
+      \ingroup functions
+  */
+  class FunStrNumber : public ICallback
+  {
+  public:
+    FunStrNumber ();
+    virtual void Eval(ptr_val_type& ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  }; // class FunStrNumber
 MUP_NAMESPACE_END
 
 #endif

--- a/parser/mpPackageStr.cpp
+++ b/parser/mpPackageStr.cpp
@@ -59,6 +59,7 @@ void PackageStr::AddToParser(ParserXBase *pParser)
   // Functions
   pParser->DefineFun(new FunStrLen());
   pParser->DefineFun(new FunStrToNumber());
+  pParser->DefineFun(new FunStrNumber());
   pParser->DefineFun(new FunStrToUpper());
   pParser->DefineFun(new FunStrToLower());
   pParser->DefineFun(new FunStrConcat());


### PR DESCRIPTION
- [x] Add `number(x)` function. A more readable version of `str2number(x)`

```rb
parsec> number("123")
Result (type: 'i'):
ans = 123

parsec> number("123321")
Result (type: 'i'):
ans = 123321

parsec> number("2.1")
Result (type: 'f'):
ans = 2.1
```