### PR TITLE
Add error message to daysdiff()

### DIFF
--- a/parser/mpParserMessageProvider.cpp
+++ b/parser/mpParserMessageProvider.cpp
@@ -104,6 +104,7 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecVARIABLE_DEFINED]             = _T("Variable \"$IDENT$\" is already defined.");
     m_vErrMsg[ecCONSTANT_DEFINED]             = _T("Constant \"$IDENT$\" is already defined.");
     m_vErrMsg[ecFUNOPRT_DEFINED]              = _T("Function/operator \"$IDENT$\" is already defined.");
+    m_vErrMsg[ecINVALID_DATE_FORMAT]          = _T("Invalid date format on \"$IDENT$\" parameter(s). Please use the \"yyyy-mm-dd\" format.");
   }
 
 #if defined(_UNICODE)

--- a/parser/mpParserMessageProvider.cpp
+++ b/parser/mpParserMessageProvider.cpp
@@ -161,11 +161,11 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecARRAY_SIZE_MISMATCH]      = _T("Feldgrößen stimmen nicht überein.");
     m_vErrMsg[ecNOT_AN_ARRAY]             = _T("Der Indexoperator kann nicht auf die Skalarvariable \"$IDENT$\" angewandt werden.");
     m_vErrMsg[ecUNEXPECTED_SQR_BRACKET]   = _T("Eckige Klammern sind an dieser Position nicht erlaubt.");
-	m_vErrMsg[ecUNEXPECTED_CURLY_BRACKET] = _T("Geschweifte Klammern sind an dieser Position nicht erlaubt.");
+	  m_vErrMsg[ecUNEXPECTED_CURLY_BRACKET] = _T("Geschweifte Klammern sind an dieser Position nicht erlaubt.");
     m_vErrMsg[ecINDEX_OUT_OF_BOUNDS]      = _T("Indexüberschreitung bei Variablenzugriff auf \"$IDENT$\".");
     m_vErrMsg[ecINDEX_DIMENSION]          = _T("Die Operation kann nicht auf Felder angewandt werden, deren Größe unterschiedlich ist.");
     m_vErrMsg[ecMISSING_SQR_BRACKET]      = _T("Fehlendes \"]\".");
-	m_vErrMsg[ecMISSING_CURLY_BRACKET]    = _T("Fehlendes \"}\".");
+	  m_vErrMsg[ecMISSING_CURLY_BRACKET]    = _T("Fehlendes \"}\".");
     m_vErrMsg[ecASSIGNEMENT_TO_VALUE]     = _T("Der Zuweisungsoperator \"$IDENT$\" kann in diesem Zusammenhang nicht verwendet werden.");
     m_vErrMsg[ecEVAL]                     = _T("Die Funktion bzw. der Operator \"$IDENT$\" kann nicht berechnet werden: $HINT$");
     m_vErrMsg[ecINVALID_PARAMETER]        = _T("Der Parameter $ARG$ der Funktion \"$IDENT$\" is ungültig.");

--- a/parser/mpTypes.h
+++ b/parser/mpTypes.h
@@ -322,7 +322,7 @@ enum EErrorCodes
     ecARRAY_SIZE_MISMATCH       = 24, ///< Array size mismatch during a vector operation
     ecNOT_AN_ARRAY              = 25, ///< Using the index operator on a scalar variable
     ecUNEXPECTED_SQR_BRACKET    = 26, ///< Invalid use of the index operator
-	ecUNEXPECTED_CURLY_BRACKET  = 27, ///< Invalid use of the index operator
+	  ecUNEXPECTED_CURLY_BRACKET  = 27, ///< Invalid use of the index operator
 
     ecINVALID_NAME              = 28, ///< Invalid function, variable or constant name.
     ecBUILTIN_OVERLOAD          = 29, ///< Trying to overload builtin operator
@@ -343,7 +343,7 @@ enum EErrorCodes
     ecINDEX_OUT_OF_BOUNDS       = 40, ///< Array index is out of bounds
     ecINDEX_DIMENSION           = 41,
     ecMISSING_SQR_BRACKET       = 42, ///< The index operator was not closed properly (i.e. "v[3")
-	ecMISSING_CURLY_BRACKET     = 43,
+	  ecMISSING_CURLY_BRACKET     = 43,
     ecEVAL                      = 44, ///< Error while evaluating function / operator
     ecOVERFLOW                  = 45, ///< Overflow (possibly) occurred
 

--- a/sample/example.cpp
+++ b/sample/example.cpp
@@ -195,7 +195,7 @@ int main(int /*argc*/, char** /*argv*/)
   }
   catch(ParserError &e)
   {
-    // Only erros raised during the initialization will end up here
+    // Only errors raised during the initialization will end up here
     // expression related errors are treated in Calc()
     console() << _T("Initialization error:  ") << e.GetMsg() << endl;
   }

--- a/value_test/mpError.cpp
+++ b/value_test/mpError.cpp
@@ -110,6 +110,7 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecMISSING_SQR_BRACKET]     = _T("Missing \"]\"");
     m_vErrMsg[ecASSIGNEMENT_TO_VALUE]    = _T("Assignment operator \"$IDENT$\" can't be used in this context");
     m_vErrMsg[ecEVAL]                    = _T("Can't evaluate function/operator \"$IDENT$\": $HINT$");
+    m_vErrMsg[ecINVALID_DATE_FORMAT]     = _T("Invalid date format on \"$IDENT$\" parameter(s). Please use the \"yyyy-mm-dd\" format.");
 
     #if defined(_DEBUG)
       for (int i=0; i<ecCOUNT; ++i)

--- a/value_test/mpError.h
+++ b/value_test/mpError.h
@@ -97,6 +97,9 @@ MUP_NAMESPACE_START
       // internal errors
       ecINTERNAL_ERROR         = 43, ///< Internal error of any kind.
 
+      // date related errors
+      ecINVALID_DATE_FORMAT    = 52, ///< Invalid date format
+
       // The last two are special entries 
       ecCOUNT,                    ///< This is no error code, It just stores just the total number of error codes
       ecUNDEFINED              = -1, ///< Undefined message, placeholder to detect unassigned error messages


### PR DESCRIPTION
Currently, if an error is raised on the `daysdiff()` function, it is a general one, like this.

```rb
Can't evaluate function/operator "daysdiff()"
```

Here, I'm changing the error message to

```rb
Invalid date format on "daysdiff()" parameter(s). Please use the "yyyy-mm-dd" format.
```