### PR TITLE
Restrict hoursdiff() parameters to exactly two dates or two datetimes

### DIFF
--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -421,12 +421,16 @@ MUP_NAMESPACE_START
 
     // Matches exactly: "yyyy-mm-dd"
     std::regex basic_date ("^\\d{4}-\\d{2}-\\d{2}$");
-
-    if (std::regex_match (date_a, basic_date)) {
+    if (std::regex_match (date_a, basic_date) && std::regex_match (date_b, basic_date)) {
       date_a = date_a + "T00:00";
-    }
-    if (std::regex_match (date_b, basic_date)) {
       date_b = date_b + "T00:00";
+    } else if (std::regex_match (date_a, basic_date) || std::regex_match (date_b, basic_date)) {
+      ErrorContext err;
+      err.Errc = ecDATE_AND_DATETIME;
+      err.Arg = 1;
+      err.Type1 = a_pArg[0]->GetType();
+      err.Type2 = 's';
+      throw ParserError(err);
     }
 
     // http://man7.org/linux/man-pages/man3/strptime.3.html

--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -422,8 +422,8 @@ MUP_NAMESPACE_START
     // Matches exactly: "yyyy-mm-dd"
     std::regex basic_date ("^\\d{4}-\\d{2}-\\d{2}$");
     if (std::regex_match (date_a, basic_date) && std::regex_match (date_b, basic_date)) {
-      date_a = date_a + "T00:00";
-      date_b = date_b + "T00:00";
+      date_a += "T00:00";
+      date_b += "T00:00";
     } else if (std::regex_match (date_a, basic_date) || std::regex_match (date_b, basic_date)) {
       ErrorContext err;
       err.Errc = ecDATE_AND_DATETIME;

--- a/parser/mpParserMessageProvider.cpp
+++ b/parser/mpParserMessageProvider.cpp
@@ -90,11 +90,11 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecARRAY_SIZE_MISMATCH]      = _T("Array size mismatch.");
     m_vErrMsg[ecNOT_AN_ARRAY]             = _T("Using the index operator on the scalar variable \"$IDENT$\" is not allowed.");
     m_vErrMsg[ecUNEXPECTED_SQR_BRACKET]   = _T("Unexpected \"[]\".");
-	m_vErrMsg[ecUNEXPECTED_CURLY_BRACKET] = _T("Unexpected \"{}\".");
+	  m_vErrMsg[ecUNEXPECTED_CURLY_BRACKET] = _T("Unexpected \"{}\".");
     m_vErrMsg[ecINDEX_OUT_OF_BOUNDS]      = _T("Index to variable \"$IDENT$\" is out of bounds.");
     m_vErrMsg[ecINDEX_DIMENSION]          = _T("Index operator dimension error.");
     m_vErrMsg[ecMISSING_SQR_BRACKET]      = _T("Missing \"]\".");
-	m_vErrMsg[ecMISSING_CURLY_BRACKET]    = _T("Missing \"}\".");
+	  m_vErrMsg[ecMISSING_CURLY_BRACKET]    = _T("Missing \"}\".");
     m_vErrMsg[ecASSIGNEMENT_TO_VALUE]     = _T("Assignment operator \"$IDENT$\" can't be used in this context.");
     m_vErrMsg[ecEVAL]                     = _T("Can't evaluate function/operator \"$IDENT$\": $HINT$");
     m_vErrMsg[ecINVALID_PARAMETER]        = _T("Parameter $ARG$ of function \"$IDENT$\" is invalid.");
@@ -104,8 +104,9 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecVARIABLE_DEFINED]             = _T("Variable \"$IDENT$\" is already defined.");
     m_vErrMsg[ecCONSTANT_DEFINED]             = _T("Constant \"$IDENT$\" is already defined.");
     m_vErrMsg[ecFUNOPRT_DEFINED]              = _T("Function/operator \"$IDENT$\" is already defined.");
-    m_vErrMsg[ecINVALID_DATE_FORMAT]          = _T("Invalid date format on \"$IDENT$\" parameter(s). Please use the \"yyyy-mm-dd\" format.");
-    m_vErrMsg[ecINVALID_DATETIME_FORMAT]      = _T("Invalid datetime format on \"$IDENT$\" parameter(s). Please use one of the following formats: 1) \"yyyy-mm-dd\" 2) \"yyyy-mm-ddTHH:MM\"");
+    m_vErrMsg[ecINVALID_DATE_FORMAT]          = _T("Invalid date format on parameter(s). Please use the \"yyyy-mm-dd\" format.");
+    m_vErrMsg[ecINVALID_DATETIME_FORMAT]      = _T("Invalid format on the parameter(s). Please use two \"yyyy-mm-dd\" for dates OR two \"yyyy-mm-ddTHH:MM\" for date_times.");
+    m_vErrMsg[ecDATE_AND_DATETIME]            = _T("Invalid parameters. You should use exactly two dates \"yyyy-mm-dd\" or two date_times \"yyyy-mm-ddTHH:MM\", but not a mix of them.");
   }
 
 #if defined(_UNICODE)

--- a/parser/mpParserMessageProvider.cpp
+++ b/parser/mpParserMessageProvider.cpp
@@ -135,7 +135,7 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecUNEXPECTED_OPERATOR]      = _T("Unerwarteter Operator \"$IDENT$\" an Position $POS$.");
     m_vErrMsg[ecUNEXPECTED_EOF]           = _T("Unerwartetes Formelende an Position $POS$.");
     m_vErrMsg[ecUNEXPECTED_COMMA]         = _T("Unerwartetes Komma an Position $POS$.");
-    m_vErrMsg[ecUNEXPECTED_PARENS  ]      = _T("Unerwartete Klammer \"$IDENT$\" an Position $POS$ gefunden.");
+    m_vErrMsg[ecUNEXPECTED_PARENS]        = _T("Unerwartete Klammer \"$IDENT$\" an Position $POS$ gefunden.");
     m_vErrMsg[ecUNEXPECTED_FUN]           = _T("Unerwartete Funktion \"$IDENT$\" an Position $POS$ gefunden.");
     m_vErrMsg[ecUNEXPECTED_VAL]           = _T("Unerwarteter Wert \"$IDENT$\" an Position $POS$ gefunden.");
     m_vErrMsg[ecUNEXPECTED_VAR]           = _T("Unerwartete Variable \"$IDENT$\" an Position $POS$ gefunden.");

--- a/parser/mpTypes.h
+++ b/parser/mpTypes.h
@@ -364,6 +364,7 @@ enum EErrorCodes
     // date related errors
     ecINVALID_DATE_FORMAT       = 52, ///< Invalid date format
     ecINVALID_DATETIME_FORMAT   = 53, ///< Invalid datetime format
+    ecDATE_AND_DATETIME         = 54, ///< Invalid hoursdiff() parameters
 
     // The last two are special entries
     ecCOUNT,                          ///< This is no error code, It just stores the total number of error codes

--- a/value_test/mpError.cpp
+++ b/value_test/mpError.cpp
@@ -110,8 +110,9 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecMISSING_SQR_BRACKET]     = _T("Missing \"]\"");
     m_vErrMsg[ecASSIGNEMENT_TO_VALUE]    = _T("Assignment operator \"$IDENT$\" can't be used in this context");
     m_vErrMsg[ecEVAL]                    = _T("Can't evaluate function/operator \"$IDENT$\": $HINT$");
-    m_vErrMsg[ecINVALID_DATE_FORMAT]     = _T("Invalid date format on \"$IDENT$\" parameter(s). Please use the \"yyyy-mm-dd\" format.");
-    m_vErrMsg[ecINVALID_DATETIME_FORMAT] = _T("Invalid datetime format on \"$IDENT$\" parameter(s). Please use one of the following formats: 1) \"yyyy-mm-dd\" 2) \"yyyy-mm-ddTHH:MM\"");
+    m_vErrMsg[ecINVALID_DATE_FORMAT]     = _T("Invalid date format on parameter(s). Please use the \"yyyy-mm-dd\" format.");
+    m_vErrMsg[ecINVALID_DATETIME_FORMAT] = _T("Invalid format on the parameter(s). Please use two \"yyyy-mm-dd\" for dates OR two \"yyyy-mm-ddTHH:MM\" for date_times.");
+    m_vErrMsg[ecDATE_AND_DATETIME]       = _T("Invalid parameters. You should use exactly two dates \"yyyy-mm-dd\" or two date_times \"yyyy-mm-ddTHH:MM\", but not a mix of them.");
 
     #if defined(_DEBUG)
       for (int i=0; i<ecCOUNT; ++i)

--- a/value_test/mpError.cpp
+++ b/value_test/mpError.cpp
@@ -74,7 +74,7 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecUNEXPECTED_OPERATOR]     = _T("Unexpected operator \"$IDENT$\" found at position $POS$");
     m_vErrMsg[ecUNEXPECTED_EOF]          = _T("Unexpected end of expression at position $POS$");
     m_vErrMsg[ecUNEXPECTED_COMMA]        = _T("Unexpected comma at position $POS$");
-    m_vErrMsg[ecUNEXPECTED_PARENS  ]     = _T("Unexpected parenthesis \"$IDENT$\" at position $POS$");
+    m_vErrMsg[ecUNEXPECTED_PARENS]       = _T("Unexpected parenthesis \"$IDENT$\" at position $POS$");
     m_vErrMsg[ecUNEXPECTED_FUN]          = _T("Unexpected function \"$IDENT$\" at position $POS$");
     m_vErrMsg[ecUNEXPECTED_VAL]          = _T("Unexpected value \"$IDENT$\" found at position $POS$");
     m_vErrMsg[ecUNEXPECTED_VAR]          = _T("Unexpected variable \"$IDENT$\" found at position $POS$");

--- a/value_test/mpError.h
+++ b/value_test/mpError.h
@@ -98,7 +98,9 @@ MUP_NAMESPACE_START
       ecINTERNAL_ERROR         = 43, ///< Internal error of any kind.
 
       // date related errors
-      ecINVALID_DATE_FORMAT    = 52, ///< Invalid date format
+      ecINVALID_DATE_FORMAT       = 52, ///< Invalid date format
+      ecINVALID_DATETIME_FORMAT   = 53, ///< Invalid datetime format
+      ecDATE_AND_DATETIME         = 54, ///< Invalid hoursdiff() parameters
 
       // The last two are special entries 
       ecCOUNT,                    ///< This is no error code, It just stores just the total number of error codes


### PR DESCRIPTION
- [x] Restrict **hoursdiff()** parameters to exactly two **dates** or two **datetimes**.
- [x] Fix error messages
- [x] Add error messages.