### PR TITLE
Display current_date() with the right format

### DIFF
--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -497,7 +497,14 @@ MUP_NAMESPACE_START
     std::time_t t = std::time(0);   // get time now
     std::tm* now = std::localtime(&t);
 
-    *ret = std::to_string(now->tm_year + 1900) + "-" + std::to_string(now->tm_mon + 1) + "-" + std::to_string(now->tm_mday);
+    string_type year  = std::to_string(now->tm_year + 1900);
+    string_type month = std::to_string(now->tm_mon + 1);
+    string_type day   = std::to_string(now->tm_mday);
+
+    month = month.length() > 1 ? month : '0' + month;
+    day = day.length() > 1 ? day : '0' + day;
+
+    *ret = year + "-" + month + "-" + day;
   }
 
   //------------------------------------------------------------------------------

--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -420,7 +420,7 @@ MUP_NAMESPACE_START
     string_type date_b = a_pArg[1]->GetString();
 
     // Matches exactly: "yyyy-mm-dd"
-    std::regex basic_date ("^\\d{4}-\\d{2}-\\d{2}$");
+    std::regex basic_date ("^\\d{4}-\\d{1,2}-\\d{1,2}$");
     if (std::regex_match (date_a, basic_date) && std::regex_match (date_b, basic_date)) {
       date_a += "T00:00";
       date_b += "T00:00";


### PR DESCRIPTION
- [x] Change `current_date()` function to always display a strict `yyyy-mm-dd` format.
- [x] Allow one digit **months** or **days** on the regex.

# New current_date() output

```rb
current_date()
"2019-03-14"
# Instead of "2019-3-14"
```

# Some test cases

```rb
parsec> current_date()
Result (type: 's'):
ans = "2019-03-14"

parsec> hoursdiff(current_date(), current_date())
Result (type: 'i'):
ans = 0

parsec> hoursdiff(current_date(), "2019-03-15")
Result (type: 'i'):
ans = 24

parsec> hoursdiff(current_date(), "2019-03-15T08:00")
        Can't evaluate function/operator "hoursdiff": Invalid parameters. You should use exactly two dates "yyyy-mm-dd" or two date_times "yyyy-mm-ddTHH:MM", but not a mix of them. (Errc: 44)
```