### PR TITLE
Add add_hours() function

### DIFF
--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -44,6 +44,7 @@
 #include "mpValue.h"
 #include "mpParserBase.h"
 
+#define ONE_DAY (24 * 60 * 60)
 
 MUP_NAMESPACE_START
 
@@ -370,8 +371,6 @@ MUP_NAMESPACE_START
   }
 
   void add_days (struct tm* date, float_type days) {
-    const time_t ONE_DAY = 24 * 60 * 60;
-
     // Avoid mismatch between winter and summer time on mktime() conversion
     date->tm_isdst = -1;
 

--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -372,7 +372,7 @@ MUP_NAMESPACE_START
   void add_days (struct tm* date, float_type days) {
     const time_t ONE_DAY = 24 * 60 * 60;
 
-    // Avoid mismatch between winter and summer time
+    // Avoid mismatch between winter and summer time on mktime() conversion
     date->tm_isdst = -1;
 
     // Seconds since start of epoch

--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -370,8 +370,7 @@ MUP_NAMESPACE_START
   }
 
   void add_days (struct tm* date, float_type days) {
-    const time_t ONE_HOUR = 60 * 60;
-    const time_t ONE_DAY = 24 * ONE_HOUR;
+    const time_t ONE_DAY = 24 * 60 * 60;
 
     // Avoid mismatch between winter and summer time
     date->tm_isdst = -1;

--- a/parser/mpFuncCommon.h
+++ b/parser/mpFuncCommon.h
@@ -123,14 +123,14 @@ MUP_NAMESPACE_START
   /** \brief Determine the difference in days between two dates.
       \ingroup functions
   */
-  class FunDateDiff : public ICallback
+  class FunDaysDiff : public ICallback
   {
   public:
-    FunDateDiff();
+    FunDaysDiff();
     virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
     virtual const char_type* GetDesc() const override;
     virtual IToken* Clone() const override;
-  }; // class FunDateDiff
+  }; // class FunDaysDiff
 
   //------------------------------------------------------------------------------
   /** \brief Determine the difference in hours between two dates.
@@ -182,7 +182,7 @@ MUP_NAMESPACE_START
   //  virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
   //  virtual const char_type* GetDesc() const override;
   //  virtual IToken* Clone() const override;
-  //}; // class FunDateDiff
+  //}; // class FunDaysDiff
 
 MUP_NAMESPACE_END
 

--- a/parser/mpFuncCommon.h
+++ b/parser/mpFuncCommon.h
@@ -159,6 +159,19 @@ MUP_NAMESPACE_START
   }; // class FunCurrentDate
 
   //------------------------------------------------------------------------------
+  /** \brief Return sum of a date/date_time with a days quantity
+      \ingroup functions
+  */
+  class FunAddDays : public ICallback
+  {
+  public:
+    FunAddDays();
+    virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  }; // class FunAddDays
+
+  //------------------------------------------------------------------------------
   /** \brief Determine the difference in days between two time.
       \ingroup functions
   */

--- a/parser/mpPackageCommon.cpp
+++ b/parser/mpPackageCommon.cpp
@@ -91,6 +91,7 @@ void PackageCommon::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunDateDiff());
   pParser->DefineFun(new FunHoursDiff());
   pParser->DefineFun(new FunCurrentDate());
+  pParser->DefineFun(new FunAddDays());
 
   // misc
   pParser->DefineFun(new FunParserID);

--- a/parser/mpPackageCommon.cpp
+++ b/parser/mpPackageCommon.cpp
@@ -88,7 +88,7 @@ void PackageCommon::AddToParser(ParserXBase *pParser)
 
 
   // Date functions
-  pParser->DefineFun(new FunDateDiff());
+  pParser->DefineFun(new FunDaysDiff());
   pParser->DefineFun(new FunHoursDiff());
   pParser->DefineFun(new FunCurrentDate());
   pParser->DefineFun(new FunAddDays());

--- a/parser/mpParserMessageProvider.cpp
+++ b/parser/mpParserMessageProvider.cpp
@@ -107,6 +107,9 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecINVALID_DATE_FORMAT]          = _T("Invalid date format on parameter(s). Please use the \"yyyy-mm-dd\" format.");
     m_vErrMsg[ecINVALID_DATETIME_FORMAT]      = _T("Invalid format on the parameter(s). Please use two \"yyyy-mm-dd\" for dates OR two \"yyyy-mm-ddTHH:MM\" for date_times.");
     m_vErrMsg[ecDATE_AND_DATETIME]            = _T("Invalid parameters. You should use exactly two dates \"yyyy-mm-dd\" or two date_times \"yyyy-mm-ddTHH:MM\", but not a mix of them.");
+    m_vErrMsg[ecADD_HOURS]                    = _T("Invalid parameters. You should use a date \"yyyy-mm-dd\" or date_time \"yyyy-mm-ddTHH:MM\" on the first parameter and a number on the second parameter.");
+    m_vErrMsg[ecADD_HOURS_DATE]               = _T("The first parameter could not be converted to a date. Please use the format: \"yyyy-mm-dd\"");
+    m_vErrMsg[ecADD_HOURS_DATETIME]           = _T("The first parameter could not be converted to a date time. Please use the format: \"yyyy-mm-ddTHH:MM\"");
   }
 
 #if defined(_UNICODE)

--- a/parser/mpTypes.h
+++ b/parser/mpTypes.h
@@ -365,6 +365,9 @@ enum EErrorCodes
     ecINVALID_DATE_FORMAT       = 52, ///< Invalid date format
     ecINVALID_DATETIME_FORMAT   = 53, ///< Invalid datetime format
     ecDATE_AND_DATETIME         = 54, ///< Invalid hoursdiff() parameters
+    ecADD_HOURS                 = 55, ///< Invalid add_hours() parameters
+    ecADD_HOURS_DATE            = 56, ///< Invalid date format for add_hours() first parameter
+    ecADD_HOURS_DATETIME        = 57, ///< Invalid date time format for add_hours() first parameter
 
     // The last two are special entries
     ecCOUNT,                          ///< This is no error code, It just stores the total number of error codes

--- a/value_test/mpError.cpp
+++ b/value_test/mpError.cpp
@@ -113,6 +113,9 @@ MUP_NAMESPACE_START
     m_vErrMsg[ecINVALID_DATE_FORMAT]     = _T("Invalid date format on parameter(s). Please use the \"yyyy-mm-dd\" format.");
     m_vErrMsg[ecINVALID_DATETIME_FORMAT] = _T("Invalid format on the parameter(s). Please use two \"yyyy-mm-dd\" for dates OR two \"yyyy-mm-ddTHH:MM\" for date_times.");
     m_vErrMsg[ecDATE_AND_DATETIME]       = _T("Invalid parameters. You should use exactly two dates \"yyyy-mm-dd\" or two date_times \"yyyy-mm-ddTHH:MM\", but not a mix of them.");
+    m_vErrMsg[ecADD_HOURS]               = _T("Invalid parameters. You should use a date/date_time on the first parameter and a number on the second parameter");
+    m_vErrMsg[ecADD_HOURS_DATE]          = _T("The first parameter could not be converted to a date. Please use the format: \"yyyy-mm-dd\"");
+    m_vErrMsg[ecADD_HOURS_DATETIME]      = _T("The first parameter could not be converted to a date time. Please use the format: \"yyyy-mm-ddTHH:MM\"");
 
     #if defined(_DEBUG)
       for (int i=0; i<ecCOUNT; ++i)

--- a/value_test/mpError.h
+++ b/value_test/mpError.h
@@ -101,6 +101,9 @@ MUP_NAMESPACE_START
       ecINVALID_DATE_FORMAT       = 52, ///< Invalid date format
       ecINVALID_DATETIME_FORMAT   = 53, ///< Invalid datetime format
       ecDATE_AND_DATETIME         = 54, ///< Invalid hoursdiff() parameters
+      ecADD_HOURS                 = 55, ///< Invalid add_hours() parameters
+      ecADD_HOURS_DATE            = 56, ///< Invalid date format for add_hours() first parameter
+      ecADD_HOURS_DATETIME        = 57, ///< Invalid date time format for add_hours() first parameter
 
       // The last two are special entries 
       ecCOUNT,                    ///< This is no error code, It just stores just the total number of error codes


### PR DESCRIPTION
- [x] Create `add_days()` function to be used to add days to a time;
- [x] Add and use some errors related to this new function.

* Extra
- [x] Add `format_date()` function to format a **time object** to a **string representation of a date/date_time**;
- [x] Create `raise_error()` function to be responsible to raise the error;
- [x] Create the section to date auxiliar functions;
- [x] Fix some bugs related to wrong number of parameters on the functions related to dates;
- [x] Change `FunDateDiff` to `FunDaysDiff`.

# Usage 
### With dates
```rb
parsec> add_days("2019-01-01", 0)
Result (type: 's'):
ans = "2019-01-01"
parsec> add_days("2019-01-01", 1)
Result (type: 's'):
ans = "2019-01-02"
parsec> add_days("2019-01-01", -1)
Result (type: 's'):
ans = "2018-12-31"
```

### With date times
```rb
parsec> add_days("2019-01-01T08:30", 0)
Result (type: 's'):
ans = "2019-01-01T08:30"
parsec> add_days("2019-01-01T08:30", 31)
Result (type: 's'):
ans = "2019-02-01T08:30"
parsec> add_days("2019-01-01T08:30", 1)
Result (type: 's'):
ans = "2019-01-02T08:30"
parsec> add_days("2019-01-01T08:30", 1.5)
Result (type: 's'):
ans = "2019-01-02T20:30"
```

### The errors
```rb
parsec> add_days("2019-01-99", 0)
        Can't evaluate function/operator "add_days": The first parameter could not be converted to a date. Please use the format: "yyyy-mm-dd" (Errc: 44)

parsec> add_days("2019-01-01T08:61", 0)
        Can't evaluate function/operator "add_days": The first parameter could not be converted to a date time. Please use the format: "yyyy-mm-ddTHH:MM" (Errc: 44)

parsec> add_days()
        Too few parameters passed to function "add_days". (Errc: 18)

parsec> add_days(1, 2, 3)
        Can't evaluate function/operator "add_days": Too many parameters passed to function "add_days". (Errc: 44)

parsec> add_days(1, 2)
        Can't evaluate function/operator "add_days": Value "1" is of type 'i'. There is no implicit conversion to type 's'. (Errc: 44)
```
