### PR TITLE
Create mask() function

### DIFF
--- a/parser/mpFuncCmplx.cpp
+++ b/parser/mpFuncCmplx.cpp
@@ -622,7 +622,7 @@ MUP_NAMESPACE_START
   //-----------------------------------------------------------------------
   const char_type* FunCmplxPow::GetDesc() const
   {
-    return _T("pox(x, y) - Raise x to the power of y.");
+    return _T("pow(x, y) - Raise x to the power of y.");
   }
 
   //-----------------------------------------------------------------------

--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -333,6 +333,63 @@ MUP_NAMESPACE_START
   }
 
   //------------------------------------------------------------------------------
+  //
+  // Mask
+  //
+  //------------------------------------------------------------------------------
+
+  string_type apply_mask(string_type mask, string_type number_string) {
+    for (int i = mask.length() - 1; i >= 0; i--) {
+      if (mask[i] == '0' && number_string.length() > 0) {
+        mask[i] = number_string.back();
+        number_string.pop_back();
+      }
+    }
+
+    if (number_string.length() > 0) {
+      mask.insert(0, number_string);
+    }
+
+    return mask;
+  }
+
+  FunMask::FunMask()
+    :ICallback(cmFUNC, _T("mask"), -1)
+  {}
+
+  //------------------------------------------------------------------------------
+  FunMask::~FunMask()
+  {}
+
+  //------------------------------------------------------------------------------
+  /** \brief Returns the application of a mask into a integer. */
+  void FunMask::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
+  {
+    if (a_iArgc < 2) {
+      throw ParserError(ErrorContext(ecTOO_FEW_PARAMS, GetExprPos(), GetIdent()));
+    } else if (a_iArgc > 2) {
+      throw ParserError(ErrorContext(ecTOO_MANY_PARAMS, GetExprPos(), GetIdent()));
+    }
+
+    string_type mask = a_pArg[0]->GetString();
+    int_type number = a_pArg[1]->GetInteger();
+
+    *ret = apply_mask(mask, std::to_string(number));
+  }
+
+  //------------------------------------------------------------------------------
+  const char_type* FunMask::GetDesc() const
+  {
+    return _T("mask(a, b) - Returns the application of the a mask into the b integer.");
+  }
+
+  //------------------------------------------------------------------------------
+  IToken* FunMask::Clone() const
+  {
+    return new FunMask(*this);
+  }
+
+  //------------------------------------------------------------------------------
   //                                                                             |
   //            Below we have the section related to Date functions              |
   //                                                                             |

--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -250,7 +250,7 @@ MUP_NAMESPACE_START
   {}
 
   //------------------------------------------------------------------------------
-  /** \brief Returns the minimum value of all values.
+  /** \brief Returns the average value of all values.
       \param a_pArg Pointer to an array of Values
       \param a_iArgc Number of values stored in a_pArg
   */

--- a/parser/mpFuncCommon.h
+++ b/parser/mpFuncCommon.h
@@ -120,6 +120,20 @@ MUP_NAMESPACE_START
   }; // class FunSizeOf
 
   //------------------------------------------------------------------------------
+  /** \brief Returns the application of a mask into a integer.
+      \ingroup functions
+  */
+  class FunMask : public ICallback
+  {
+  public:
+    FunMask();
+    virtual ~FunMask();
+    virtual void Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  }; // class FunMask
+
+  //------------------------------------------------------------------------------
   /** \brief Determine the difference in days between two dates.
       \ingroup functions
   */

--- a/parser/mpPackageCommon.cpp
+++ b/parser/mpPackageCommon.cpp
@@ -104,7 +104,7 @@ void PackageCommon::AddToParser(ParserXBase *pParser)
   pParser->DefineOprt(new OprtShr);
   pParser->DefineOprt(new OprtShl);
 
-  // booloean package
+  // boolean package
   pParser->DefineOprt(new OprtLE);
   pParser->DefineOprt(new OprtGE);
   pParser->DefineOprt(new OprtLT);

--- a/parser/mpPackageCommon.cpp
+++ b/parser/mpPackageCommon.cpp
@@ -86,6 +86,8 @@ void PackageCommon::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunSum());
   pParser->DefineFun(new FunAvg());
 
+  // Special functions
+  pParser->DefineFun(new FunMask());
 
   // Date functions
   pParser->DefineFun(new FunDaysDiff());


### PR DESCRIPTION
* Create the `mask()` function, which applies a **mask** into a **number**.

# Syntax
```rb
mask(string, integer)
```

# Examples
```rb
parsec> mask("000-000", 14)
Result (type: 's'):
ans = "000-014"

parsec> mask("000-000", 992992)
Result (type: 's'):
ans = "992-992"

parsec> mask("000-000", 992992992)
Result (type: 's'):
ans = "992992-992"

parsec> mask("000-000", 0) 
Result (type: 's'):
ans = "000-000"

parsec> mask("000-000", 1.4)
        Can't evaluate function/operator "mask": Value "1.4" is of type 'f'. There is no implicit conversion to type 'i'. (Errc: 44)

parsec> mask("00 00", 123)  
Result (type: 's'):
ans = "01 23"

parsec> concat("#", mask("000-000", 1234))
Result (type: 's'):
ans = "#001-234"
```