### PR TITLE
Remove time from current_date() function

### DIFF
--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -584,10 +584,11 @@ MUP_NAMESPACE_START
     if (a_iArgc != 0)
       throw ParserError(ErrorContext(ecTOO_MANY_PARAMS, GetExprPos(), GetIdent()));
 
+    (void)*a_pArg;
     std::time_t t = std::time(0); // get time now
     std::tm now = *std::localtime(&t);
 
-    *ret = format_date(now, true);
+    *ret = format_date(now, false);
   }
 
   //------------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Dont show the Time for the current_date() function

# Before
```rb
2.5.0 :010 > Parsec::Parsec.eval_equation("current_date()")
 => "2019-04-23T18:27" 
```

# After
```rb
2.5.0 :010 > Parsec::Parsec.eval_equation("current_date()")
 => "2019-04-23" 
```