### PR TITLE
Allow more number digits on mask() second parameter

### DIFF
--- a/parser/mpFuncCommon.cpp
+++ b/parser/mpFuncCommon.cpp
@@ -338,7 +338,17 @@ MUP_NAMESPACE_START
   //
   //------------------------------------------------------------------------------
 
-  string_type apply_mask(string_type mask, string_type number_string) {
+  static string_type to_string(long_double_type number) {
+    std::string string_number = std::to_string (number);
+    int offset = 1;
+    if (string_number.find_last_not_of('0') == string_number.find('.')) {
+      offset = 0;
+    }
+    string_number.erase(string_number.find_last_not_of('0') + offset, std::string::npos);
+    return string_number;
+  }
+
+  static string_type apply_mask(string_type mask, string_type number_string) {
     for (int i = mask.length() - 1; i >= 0; i--) {
       if (mask[i] == '0' && number_string.length() > 0) {
         mask[i] = number_string.back();
@@ -372,9 +382,9 @@ MUP_NAMESPACE_START
     }
 
     string_type mask = a_pArg[0]->GetString();
-    int_type number = a_pArg[1]->GetInteger();
+    long_double_type number = a_pArg[1]->GetFloat();
 
-    *ret = apply_mask(mask, std::to_string(number));
+    *ret = apply_mask(mask, to_string(std::round(number)));
   }
 
   //------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Previously, the `mask(string, integer)` function was not working properly if the `integer` value had more than **7 digits**.
Now, it is accepting more digits, the mistake only happens when the `integer` value has more than **17 digits**.

### Checks

- [x] Allow more decimal digits to mask second parameter
- [x] Smoke Tests

## Tests

```rb
parsec> mask("00-0000-0000", 1212341234)
Result (type: 's'):
ans = "12-1234-1234"
# PERFECT!

parsec> mask("00-0000-0000-0000", 12123412341234)
Result (type: 's'):
ans = "12-1234-1234-1234"
# PERFECT!

parsec> mask("00-0000-0000-0000-0000", 121234123412341234)
Result (type: 's'):
ans = "12-1234-1234-1234-1232"
# ^ The error now happens only here!
```