### PR TITLE
Adds link() function to generate an HTML anchor tag

### DIFF
--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -74,6 +74,36 @@ MUP_NAMESPACE_START
 
   //------------------------------------------------------------------------------
   //
+  // Link function
+  //
+  //------------------------------------------------------------------------------
+
+  FunStrLink::FunStrLink()
+    :ICallback(cmFUNC, _T("link"), 2)
+  {}
+
+  //------------------------------------------------------------------------------
+  void FunStrLink::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int)
+  {
+    string_type str1 = a_pArg[0]->GetString();
+    string_type str2 = a_pArg[1]->GetString();
+    *ret = (string_type) "<a href='" + str2 +"'>" + str1 + "</a>";
+  }
+
+  //------------------------------------------------------------------------------
+  const char_type* FunStrLink::GetDesc() const
+  {
+    return _T("link(s1, s2) - Returns the <a href='s2'>s1</a> tag with param values.");
+  }
+
+  //------------------------------------------------------------------------------
+  IToken* FunStrLink::Clone() const
+  {
+    return new FunStrLink(*this);
+  }
+
+  //------------------------------------------------------------------------------
+  //
   // Left function
   //
   //------------------------------------------------------------------------------

--- a/parser/mpFuncStr.h
+++ b/parser/mpFuncStr.h
@@ -51,6 +51,19 @@ MUP_NAMESPACE_START
   };
 
   //------------------------------------------------------------------------------
+  /** \brief Callback object for determining the anchor tag <a> using two strings.
+      \ingroup functions
+  */
+  class FunStrLink : public ICallback
+  {
+  public:
+    FunStrLink();
+    virtual void Eval(ptr_val_type& ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  };
+
+  //------------------------------------------------------------------------------
   /** \brief Callback object for determining the left part of a string.
       \ingroup functions
   */

--- a/parser/mpPackageStr.cpp
+++ b/parser/mpPackageStr.cpp
@@ -63,6 +63,7 @@ void PackageStr::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunStrToUpper());
   pParser->DefineFun(new FunStrToLower());
   pParser->DefineFun(new FunStrConcat());
+  pParser->DefineFun(new FunStrLink());
   pParser->DefineFun(new FunStrLeft());
   pParser->DefineFun(new FunStrRight());
   pParser->DefineFun(new FunStrDefaultValue());


### PR DESCRIPTION
- [x] Add `link(string1, string2)` function for string typed values.

* INPUT
```
link("Hello World", "http://foo.bar/baz")
```

* OUTPUT
```
"<a href='http://foo.bar/baz'>Hello World</a>"
```


![image](https://user-images.githubusercontent.com/7280753/110638321-2d945600-818d-11eb-9422-bf0618953ee2.png)
