### PR TITLE
Fixes quotes escaping in link() function

### DIFF
--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -87,13 +87,13 @@ MUP_NAMESPACE_START
   {
     string_type str1 = a_pArg[0]->GetString();
     string_type str2 = a_pArg[1]->GetString();
-    *ret = (string_type) "<a href=\\\"" + str2 +"\\\">" + str1 + "</a>";
+    *ret = (string_type) "<a href=\"" + str2 +"\">" + str1 + "</a>";
   }
 
   //------------------------------------------------------------------------------
   const char_type* FunStrLink::GetDesc() const
   {
-    return _T("link(s1, s2) - Returns the <a href=\\\"s2\\\">s1</a> tag with param values.");
+    return _T("link(s1, s2) - Returns the <a href=\"s2\">s1</a> tag with param values.");
   }
 
   //------------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Fixes double quotes escaping in `link()` function.

## Before

* INPUT
```
link("Hello World", "http://foo.bar/baz")
```

* OUTPUT
```
"<a href=\"http://foo.bar/baz\">Hello World</a>"
```

## After

* INPUT
```
link("Hello World", "http://foo.bar/baz")
```

* OUTPUT
```
"<a href="http://foo.bar/baz">Hello World</a>"
```


![image](https://user-images.githubusercontent.com/7280753/110845050-eab7a880-8288-11eb-8c0f-190b30c9e344.png)
