### PR TITLE
Allow string(x) function tor receive strings

### DIFF
--- a/parser/mpFuncNonCmplx.cpp
+++ b/parser/mpFuncNonCmplx.cpp
@@ -58,15 +58,6 @@ double round(long_double_type number, int_type precision) {
   return (std::round(number * decimals)) / decimals;
 }
 
-string_type to_string(long_double_type number) {
-  std::string string_number = std::to_string (number);
-  int offset = 1;
-  if (string_number.find_last_not_of('0') == string_number.find('.')) {
-    offset = 0;
-  }
-  string_number.erase(string_number.find_last_not_of('0') + offset, std::string::npos);
-  return string_number;
-}
 //------------------------------------------------------------------------------
 //
 //
@@ -121,7 +112,6 @@ string_type to_string(long_double_type number) {
     // number functions
     MUP_UNARY_FUNC(FunAbs,   "abs",    std::fabs,  "abs(x) - absolute value of x")
     MUP_UNARY_FUNC(FunRound, "round",  std::round, "round(x) - round the value of x to its nearest integer")
-    MUP_UNARY_FUNC(FunString,"string", to_string,  "string(x) - converts the number from decimal to string")
 #undef MUP_UNARY_FUNC
 
 #define MUP_BINARY_FUNC(CLASS, IDENT, FUNC, DESC) \

--- a/parser/mpFuncNonCmplx.h
+++ b/parser/mpFuncNonCmplx.h
@@ -82,7 +82,6 @@ MUP_NAMESPACE_START
     // number functions
     MUP_UNARY_FUNC_DEF(FunAbs)
     MUP_UNARY_FUNC_DEF(FunRound)
-    MUP_UNARY_FUNC_DEF(FunString)
 #undef MUP_UNARY_FUNC_DEF
 
 #define MUP_BINARY_FUNC_DEF(CLASS)                                          \

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -488,6 +488,7 @@ MUP_NAMESPACE_START
 
     int_type    integer_value;
     float_type  float_value;
+    bool_type   bool_value;
     string_type string_value;
 
     if (a_pArg[0]->GetType() == 'i') {
@@ -498,6 +499,11 @@ MUP_NAMESPACE_START
     if (a_pArg[0]->GetType() == 'f') {
       float_value = a_pArg[0]->GetFloat();
       *ret = (string_type) to_string(float_value);
+    }
+
+    if (a_pArg[0]->GetType() == 'b') {
+      bool_value = a_pArg[0]->GetBool();
+      *ret = (string_type) (bool_value ? "true" : "false");
     }
 
     if (a_pArg[0]->GetType() == 's') {

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -457,4 +457,60 @@ MUP_NAMESPACE_START
   {
     return new FunStrNumber(*this);
   }
+
+  //------------------------------------------------------------------------------
+  //
+  // String cast => string()
+  //
+  //------------------------------------------------------------------------------
+
+  // auxiliary string() functions
+  string_type to_string(long_double_type number) {
+    std::string string_number = std::to_string (number);
+    int offset = 1;
+    if (string_number.find_last_not_of('0') == string_number.find('.')) {
+      offset = 0;
+    }
+    string_number.erase(string_number.find_last_not_of('0') + offset, std::string::npos);
+    return string_number;
+  }
+
+  // string() defines
+  FunString::FunString()
+    :ICallback(cmFUNC, _T("string"), 1)
+  {}
+
+  //------------------------------------------------------------------------------
+  void FunString::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
+  {
+    assert(a_iArgc==1);
+    _unused(a_iArgc);
+
+    int_type integer_value;
+    string_type string_value;
+
+    if (a_pArg[0]->GetType() == 'i') {
+      integer_value = a_pArg[0]->GetInteger();
+      *ret = (string_type) to_string(integer_value);
+    }
+
+    if (a_pArg[0]->GetType() == 's') {
+      string_value = a_pArg[0]->GetString();
+      *ret = (string_type) string_value;
+    }
+
+    return;
+  }
+
+  //------------------------------------------------------------------------------
+  const char_type* FunString::GetDesc() const
+  {
+    return _T("string(x) - converts the value to string.");
+  }
+
+  //------------------------------------------------------------------------------
+  IToken* FunString::Clone() const
+  {
+    return new FunString(*this);
+  }
 MUP_NAMESPACE_END

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -487,7 +487,7 @@ MUP_NAMESPACE_START
     _unused(a_iArgc);
 
     int_type    integer_value;
-    float_type float_value;
+    float_type  float_value;
     string_type string_value;
 
     if (a_pArg[0]->GetType() == 'i') {

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -486,12 +486,18 @@ MUP_NAMESPACE_START
     assert(a_iArgc==1);
     _unused(a_iArgc);
 
-    int_type integer_value;
+    int_type    integer_value;
+    float_type float_value;
     string_type string_value;
 
     if (a_pArg[0]->GetType() == 'i') {
       integer_value = a_pArg[0]->GetInteger();
       *ret = (string_type) to_string(integer_value);
+    }
+
+    if (a_pArg[0]->GetType() == 'f') {
+      float_value = a_pArg[0]->GetFloat();
+      *ret = (string_type) to_string(float_value);
     }
 
     if (a_pArg[0]->GetType() == 's') {

--- a/parser/mpFuncStr.h
+++ b/parser/mpFuncStr.h
@@ -166,6 +166,19 @@ MUP_NAMESPACE_START
     virtual const char_type* GetDesc() const override;
     virtual IToken* Clone() const override;
   }; // class FunStrNumber
+
+//------------------------------------------------------------------------------
+  /** \brief Parse number/string to a string value.
+      \ingroup functions
+  */
+  class FunString : public ICallback
+  {
+  public:
+    FunString ();
+    virtual void Eval(ptr_val_type& ret, const ptr_val_type *a_pArg, int a_iArgc) override;
+    virtual const char_type* GetDesc() const override;
+    virtual IToken* Clone() const override;
+  }; // class FunString
 MUP_NAMESPACE_END
 
 #endif

--- a/parser/mpPackageNonCmplx.cpp
+++ b/parser/mpPackageNonCmplx.cpp
@@ -76,7 +76,6 @@ void PackageNonCmplx::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunCbrt());
   pParser->DefineFun(new FunAbs());
   pParser->DefineFun(new FunRound());
-  pParser->DefineFun(new FunString());
 
   // binary functions
   pParser->DefineFun(new FunPow());

--- a/parser/mpPackageStr.cpp
+++ b/parser/mpPackageStr.cpp
@@ -67,6 +67,7 @@ void PackageStr::AddToParser(ParserXBase *pParser)
   pParser->DefineFun(new FunStrLeft());
   pParser->DefineFun(new FunStrRight());
   pParser->DefineFun(new FunStrDefaultValue());
+  pParser->DefineFun(new FunString());
 
   // Operators
   pParser->DefineOprt(new OprtStrAdd);


### PR DESCRIPTION
Previously, if the **`string(x)`** function received a **string** value, the result was `"0"`.

It happened because it was only able to receive **number** values. For example: `string(4)` => `"4"`.

Now, the **`string(x)`** function is able to receive all kind of values:

1. **integer**
2. **decimal**
3. **boolean**
3. **string** 

```rb
$ ./example

parsec> string(4)
Result (type: 's'):
ans = "4"

parsec> string("4")
Result (type: 's'):
ans = "4"

parsec> string(true)
Result (type: 's'):
ans = "true"

parsec> string("Hello World")
Result (type: 's'):
ans = "Hello World"

parsec> exit
```
