### PR TITLE
Fix right(x, y) function to work with cut size bigger than string length

### DIFF
--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -182,6 +182,8 @@ MUP_NAMESPACE_START
     string_type str = a_pArg[0]->GetString();
     int cut = a_pArg[1]->GetInteger();
 
+    cut = std::min(cut, (int)str.size());
+
     str = str.substr(str.size() - cut, str.size());
 
     *ret = (string_type) str;


### PR DESCRIPTION
Fix a bug where right('str', 4) (or any value greater than string lenght) would throw an std::out_of_range error.

Before:
![OutOfRange](https://user-images.githubusercontent.com/26317903/134062025-dd4076dc-9ae0-437c-ab48-f3a89cacb5a8.png)

After: 
![WorkingAsIntended](https://user-images.githubusercontent.com/26317903/134062054-163b4f7b-f581-4a26-8e52-92d016e060b5.png)

[Jira's Ticket](https://kaeferdpms.atlassian.net/browse/DPMS-14779) 