### PR TITLE
Adds optional attribute download to link() equation

### DIFF
--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -35,6 +35,7 @@
 #include <cstdio>
 #include <cwchar>
 #include <algorithm>
+#include <iostream>
 
 #include "mpValue.h"
 #include "mpError.h"
@@ -110,21 +111,23 @@ MUP_NAMESPACE_START
   //------------------------------------------------------------------------------
 
   FunStrLink::FunStrLink()
-    :ICallback(cmFUNC, _T("link"), 2)
+    :ICallback(cmFUNC, _T("link"), -1)
   {}
 
   //------------------------------------------------------------------------------
-  void FunStrLink::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int)
+  void FunStrLink::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
   {
     string_type str1 = a_pArg[0]->GetString();
     string_type str2 = a_pArg[1]->GetString();
-    *ret = (string_type) "<a href=\"" + str2 +"\">" + str1 + "</a>";
+    string_type opAttr = a_iArgc > 2 ? "download=\"" + a_pArg[2]->GetString() + "\">" : ">";
+    *ret = (string_type) "<a href=\"" + str2 +"\"" + opAttr + str1 + "</a>";
   }
 
   //------------------------------------------------------------------------------
   const char_type* FunStrLink::GetDesc() const
   {
-    return _T("link(s1, s2) - Returns the <a href=\"s2\">s1</a> tag with param values.");
+    return _T("link(s1, s2) - Returns the <a href=\"s2\">s1</a> tag with param values.")
+           _T("link(s1, s2, s3) - Returns the <a href=\"s2\" download=\"s3\">s1</a> tag with param values.");
   }
 
   //------------------------------------------------------------------------------

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -116,6 +116,9 @@ MUP_NAMESPACE_START
   //------------------------------------------------------------------------------
   void FunStrLink::Eval(ptr_val_type &ret, const ptr_val_type *a_pArg, int a_iArgc)
   {
+    if (a_iArgc < 2)
+      throw ParserError(ErrorContext(ecTOO_FEW_PARAMS, GetExprPos(), GetIdent()));
+
     string_type str1 = a_pArg[0]->GetString();
     string_type str2 = a_pArg[1]->GetString();
     string_type opAttr = a_iArgc > 2 ? "download=\"" + a_pArg[2]->GetString() + "\">" : ">";

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -35,7 +35,6 @@
 #include <cstdio>
 #include <cwchar>
 #include <algorithm>
-#include <iostream>
 
 #include "mpValue.h"
 #include "mpError.h"

--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -118,11 +118,13 @@ MUP_NAMESPACE_START
   {
     if (a_iArgc < 2)
       throw ParserError(ErrorContext(ecTOO_FEW_PARAMS, GetExprPos(), GetIdent()));
+    if (a_iArgc > 3)
+      throw ParserError(ErrorContext(ecTOO_MANY_PARAMS, GetExprPos(), GetIdent()));
 
     string_type str1 = a_pArg[0]->GetString();
     string_type str2 = a_pArg[1]->GetString();
-    string_type opAttr = a_iArgc > 2 ? "download=\"" + a_pArg[2]->GetString() + "\">" : ">";
-    *ret = (string_type) "<a href=\"" + str2 +"\"" + opAttr + str1 + "</a>";
+    string_type opAttr = a_iArgc == 3 ? "download=\"" + a_pArg[2]->GetString() + "\">" : ">";
+    *ret = (string_type) "<a href=\"" + str2 +"\" " + opAttr + str1 + "</a>";
   }
 
   //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds an optional attribute download to the link equation.

Now is possible to pass an additional string parameter which will be the file name in case of a downloadable file link.

![image](https://user-images.githubusercontent.com/38773806/191341488-ceaf2e4b-77ac-4b6a-855c-f22ca25c604a.png)

> It will be possible to pass more than 3 parameters, but in this update, only the 3 firsts will be used in the anchor tag returned. 
> It will also be possible to pass less than 2 parameters, in these cases, the link returns nothing.