### PR TITLE
Fixing float precision when converting AsString

### DIFF
--- a/parser/mpValue.cpp
+++ b/parser/mpValue.cpp
@@ -33,6 +33,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "mpValue.h"
 #include "mpError.h"
 #include "mpValueCache.h"
+#include <iomanip>
 
 
 MUP_NAMESPACE_START
@@ -764,7 +765,7 @@ string_type Value::AsString() const
     switch (m_cType)
     {
     case 'i': ss << (int_type)m_val.real(); break;
-    case 'f': ss << m_val.real(); break;
+    case 'f': ss << std::setprecision(std::numeric_limits<float_type>::digits10) << GetFloat(); break;
     case 'm': ss << _T("(matrix)"); break;
     case 's':
         assert(m_psVal != nullptr);


### PR DESCRIPTION
This PR aims to fix the float precision when converting as String.

Now the `AsString` function returns much higher numerical precision for `float` values:

| Before | Now |
| ------------------- | ------------------- |
|![parsec precision before](https://user-images.githubusercontent.com/13650290/203382597-8cba4b9e-41f8-4581-a199-43c0336fdf0b.png) | ![parsec precision now](https://user-images.githubusercontent.com/13650290/203382629-2eece2a6-c4ea-4850-b584-92dea5f93910.png) |
