### PR TITLE
Create helper functions inside EquationParser namespace

### DIFF
--- a/parser/equationsParser.cpp
+++ b/parser/equationsParser.cpp
@@ -1,0 +1,130 @@
+#include "equationsParser.h"
+
+#include <string>
+#include <iostream>
+#include <cmath>
+#include <vector>
+
+using namespace std;
+using namespace mup;
+
+MUP_NAMESPACE_START
+
+string EquationsParserCalc(string input) {
+  ParserX parser(pckALL_NON_COMPLEX);
+
+  Value ans;
+  parser.DefineVar(_T("ans"), Variable(&ans));
+
+  try
+  {
+    parser.SetExpr(input);
+    ans = parser.Eval();
+
+    return ans.AsString();
+  }
+  catch(ParserError &e)
+  {
+    if (e.GetPos() != -1) {
+      string_type error = "Error: ";
+      error.append(e.GetMsg());
+      return error;
+    }
+  }
+  catch(std::runtime_error & ex)
+  {
+    string_type error = "Error: Runtime error - ";
+    error.append(ex.what());
+    return error;
+  }
+  return ans.AsString();
+}
+
+/**
+ * @brief Replaces all occurrences of the substring @from in the source string with another the
+ * substring @to
+ * @param source A reference to the string to perform the replacement on
+ * @param from The substring to be replaced
+ * @param to The substring that will replace 'from'
+ */
+void EquationsParserReplaceAll(std::string& source, const std::string& from, const std::string& to) {
+  std::string newString;
+  newString.reserve(source.length());  // avoids a few memory allocations
+
+  std::string::size_type lastPos = 0;
+  std::string::size_type findPos;
+
+  while(std::string::npos != (findPos = source.find(from, lastPos)))
+  {
+    newString.append(source, lastPos, findPos - lastPos);
+    newString += to;
+    lastPos = findPos + from.length();
+  }
+
+  // Care for the rest after last occurrence
+  newString += source.substr(lastPos);
+
+  source.swap(newString);
+}
+
+/**
+ * @brief Evaluates an input string as a mathematical expression and returns the result as a JSON
+ * @param input The string to be evaluated as a mathematical expression
+ * @return The result of the evaluation as a JSON string in the following format:
+ * {
+ *    "val": "result_value",
+ *    "type": "result_type"
+ * }
+ * or in case of error:
+ * {
+ *    "error": "error_message"
+ * }
+ */
+string EquationsParserCalcJson(string input) {
+  ParserX parser(pckALL_NON_COMPLEX);
+
+  Value ans;
+  parser.DefineVar(_T("ans"), Variable(&ans));
+
+  stringstream_type ss;
+
+  ss << _T("{");
+
+  try
+  {
+    parser.SetExpr(input);
+    ans = parser.Eval();
+
+    std::string ansString = ans.AsString();
+
+    EquationsParserReplaceAll(ansString, "\"", "\\\"");
+
+    ss << _T("\"val\": \"") << ansString << _T("\"");
+    ss << _T(",\"type\": \"") << ans.GetType() << _T("\"");
+  }
+  catch(ParserError &e)
+  {
+    if (e.GetPos() != -1) {
+      string_type error = e.GetMsg();
+      ss << _T("\"error\": \"") << error << _T("\"");
+    }
+  }
+  catch(std::runtime_error & ex)
+  {
+    string_type error = "Error: Runtime error - ";
+    error.append(ex.what());
+    ss << _T("\"error\": \"") << error << _T("\"");
+  }
+
+  ss << _T("}");
+
+  return ss.str();
+}
+
+void EquationsParserCalcArray(vector<string> equations, vector<string> &out) {
+  for(string equation : equations) {
+    out.push_back(EquationsParserCalcJson(equation));
+  }
+}
+
+MUP_NAMESPACE_END

--- a/parser/equationsParser.cpp
+++ b/parser/equationsParser.cpp
@@ -8,9 +8,13 @@
 using namespace std;
 using namespace mup;
 
-MUP_NAMESPACE_START
+EQUATIONS_PARSER_START
 
-string EquationsParserCalc(string input) {
+/**
+ * @brief Evaluates an input string as a mathematical expression and returns the result
+ * @param input The string to be evaluated as a mathematical expression
+ */
+string Calc(string input) {
   ParserX parser(pckALL_NON_COMPLEX);
 
   Value ans;
@@ -47,7 +51,7 @@ string EquationsParserCalc(string input) {
  * @param from The substring to be replaced
  * @param to The substring that will replace 'from'
  */
-void EquationsParserReplaceAll(std::string& source, const std::string& from, const std::string& to) {
+void ReplaceAll(std::string& source, const std::string& from, const std::string& to) {
   std::string newString;
   newString.reserve(source.length());  // avoids a few memory allocations
 
@@ -80,7 +84,7 @@ void EquationsParserReplaceAll(std::string& source, const std::string& from, con
  *    "error": "error_message"
  * }
  */
-string EquationsParserCalcJson(string input) {
+string CalcJson(string input) {
   ParserX parser(pckALL_NON_COMPLEX);
 
   Value ans;
@@ -97,7 +101,7 @@ string EquationsParserCalcJson(string input) {
 
     std::string ansString = ans.AsString();
 
-    EquationsParserReplaceAll(ansString, "\"", "\\\"");
+    ReplaceAll(ansString, "\"", "\\\"");
 
     ss << _T("\"val\": \"") << ansString << _T("\"");
     ss << _T(",\"type\": \"") << ans.GetType() << _T("\"");
@@ -121,10 +125,16 @@ string EquationsParserCalcJson(string input) {
   return ss.str();
 }
 
-void EquationsParserCalcArray(vector<string> equations, vector<string> &out) {
+/**
+ * Calculates the result of a list of equations and stores them in the 'out' vector.
+ *
+ * @param equations a vector of strings representing mathematical equations
+ * @param out a vector of strings where the results of the calculations will be stored
+ */
+void CalcArray(vector<string> equations, vector<string> &out) {
   for(string equation : equations) {
-    out.push_back(EquationsParserCalcJson(equation));
+    out.push_back(CalcJson(equation));
   }
 }
 
-MUP_NAMESPACE_END
+EQUATIONS_PARSER_END

--- a/parser/equationsParser.h
+++ b/parser/equationsParser.h
@@ -6,13 +6,16 @@
 #include "mpParser.h"
 #include "mpDefines.h"
 
-MUP_NAMESPACE_START
+#define EQUATIONS_PARSER_START namespace EquationsParser {
+#define EQUATIONS_PARSER_END }
 
-void EquationsParserReplaceAll(std::string& source, const std::string& from, const std::string& to);
-std::string EquationsParserCalc(std::string input);
-std::string EquationsParserCalcJson(std::string input);
-void EquationsParserCalcArray(std::vector<std::string> in, std::vector<std::string> &out);
+EQUATIONS_PARSER_START
 
-MUP_NAMESPACE_END
+void ReplaceAll(std::string& source, const std::string& from, const std::string& to);
+std::string Calc(std::string input);
+std::string CalcJson(std::string input);
+void CalcArray(std::vector<std::string> in, std::vector<std::string> &out);
+
+EQUATIONS_PARSER_END
 
 #endif

--- a/parser/equationsParser.h
+++ b/parser/equationsParser.h
@@ -1,0 +1,18 @@
+#ifndef EQUATIONS_PARSER_H
+#define EQUATIONS_PARSER_H
+
+#include <string>
+//--- Parser framework -----------------------------------------------------
+#include "mpParser.h"
+#include "mpDefines.h"
+
+MUP_NAMESPACE_START
+
+void EquationsParserReplaceAll(std::string& source, const std::string& from, const std::string& to);
+std::string EquationsParserCalc(std::string input);
+std::string EquationsParserCalcJson(std::string input);
+void EquationsParserCalcArray(std::vector<std::string> in, std::vector<std::string> &out);
+
+MUP_NAMESPACE_END
+
+#endif

--- a/sample/example.cpp
+++ b/sample/example.cpp
@@ -173,6 +173,18 @@ void Calc()
   } // for (;;)
 } // Calc
 
+void EquationsParserSample() {
+  console() << _T(EquationsParser::CalcJson("sin(0.57) * 33")) << endl;
+  console() << _T(EquationsParser::Calc("sin(0.57) * 33")) << endl;
+
+  vector<string> equations = {"5*7", "40+2"};
+  vector<string> results;
+  EquationsParser::CalcArray(equations, results);
+  for (string r : results) {
+    console() << _T(r) << endl;
+  }
+}
+
 //---------------------------------------------------------------------------
 int main(int /*argc*/, char** /*argv*/)
 {
@@ -189,14 +201,8 @@ int main(int /*argc*/, char** /*argv*/)
   //// Characters.
   //ParserX::ResetErrorMessageProvider(new mup::ParserMessageProviderGerman);
 #endif
-  console() << _T(EquationsParserCalcJson("sin(0.57) * 33")) << endl;
-  console() << _T(EquationsParserCalc("sin(0.57) * 33")) << endl;
-  vector<string> equations = {"5*7", "40+2"};
-  vector<string> results;
-  EquationsParserCalcArray(equations, results);
-  for (string r : results) {
-    console() << _T(r) << endl;
-  }
+
+  EquationsParserSample();
 
   try
   {

--- a/sample/example.cpp
+++ b/sample/example.cpp
@@ -6,43 +6,43 @@
 <pre>
                __________                                 ____  ___
     _____  __ _\______   \_____ _______  ______ __________\   \/  /
-   /     \|  |  \     ___/\__  \\_  __ \/  ___// __ \_  __ \     / 
-  |  Y Y  \  |  /    |     / __ \|  | \/\___ \\  ___/|  | \/     \ 
+   /     \|  |  \     ___/\__  \\_  __ \/  ___// __ \_  __ \     /
+  |  Y Y  \  |  /    |     / __ \|  | \/\___ \\  ___/|  | \/     \
   |__|_|  /____/|____|    (____  /__|  /____  >\___  >__| /___/\  \
         \/                     \/           \/     \/           \_/
                                        Copyright (C) 2016, Ingo Berg
                                        All rights reserved.
 
-  Redistribution and use in source and binary forms, with or without 
+  Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
 
-   * Redistributions of source code must retain the above copyright notice, 
+   * Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above copyright notice, 
-     this list of conditions and the following disclaimer in the documentation 
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
 
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 </pre>
 */
 
 /** \brief This macro will enable mathematical constants like M_PI. */
-#define _USE_MATH_DEFINES 
+#define _USE_MATH_DEFINES
 
 /** \brief Needed to ensure successfull compilation on Unicode systems with MinGW. */
 #undef __STRICT_ANSI__
 
 //--- Standard include ------------------------------------------------------
-#if defined(_WIN32) 
+#if defined(_WIN32)
   // Memory leak dumping
   #if defined(_DEBUG)
     #define _CRTDBG_MAP_ALLOC
@@ -69,6 +69,7 @@
 //--- muparserx framework -------------------------------------------------------------------------
 #include "mpParser.h"
 #include "mpDefines.h"
+#include "equationsParser.h"
 
 //--- other includes ------------------------------------------------------------------------------
 #include "timer.h"
@@ -144,7 +145,7 @@ void Calc()
       case  0: break;
       case -1: return;
       }
-    
+
       parser.SetExpr(sLine);
 
       // The returned result is of type Value, value is a Variant like
@@ -184,10 +185,18 @@ int main(int /*argc*/, char** /*argv*/)
       throw std::runtime_error("Can't set \"stdout\" to UTF-8");
   #endif
 
-  //// Internationalization requires UNICODE as translations do contain non ASCII 
+  //// Internationalization requires UNICODE as translations do contain non ASCII
   //// Characters.
   //ParserX::ResetErrorMessageProvider(new mup::ParserMessageProviderGerman);
 #endif
+  console() << _T(EquationsParserCalcJson("sin(0.57) * 33")) << endl;
+  console() << _T(EquationsParserCalc("sin(0.57) * 33")) << endl;
+  vector<string> equations = {"5*7", "40+2"};
+  vector<string> results;
+  EquationsParserCalcArray(equations, results);
+  for (string r : results) {
+    console() << _T(r) << endl;
+  }
 
   try
   {
@@ -203,9 +212,9 @@ int main(int /*argc*/, char** /*argv*/)
   {
     console() << _T("aborting...") << endl;
   }
-  
-#ifdef MUP_LEAKAGE_REPORT  
-  IToken::LeakageReport();  
+
+#ifdef MUP_LEAKAGE_REPORT
+  IToken::LeakageReport();
 #endif
 
   return 0;


### PR DESCRIPTION
    Create helper functions inside EquationParser namespace

    Move extension functions Calc, CalcJson, ReplaceAll and CalcArray to
    equations parser.

    Creates namespace EquationsParser

    Usage reference:

      EquationsParser::CalcJson("sin(0.57) * 33");
      EquationsParser::Calc("sin(0.57) * 33");

      vector<string> equations = {"5*7", "40+2"};
      vector<string> results;
      EquationsParser::CalcArray(equations, results);
